### PR TITLE
Fixing sprite render order

### DIFF
--- a/Assets/SpriteSheetRenderer/Material/SpriteSheet.shader
+++ b/Assets/SpriteSheetRenderer/Material/SpriteSheet.shader
@@ -59,7 +59,7 @@
                 //rotate the vertex
                 v.vertex = mul(v.vertex-float4(0.5,0.5,0,0),rotationZMatrix(transform.z));
                 //scale it
-                float3 worldPosition = float3(transform.x,transform.y,-transform.y/10) + (v.vertex.xyz * transform.w);
+                float3 worldPosition = float3(transform.x, transform.y, transform.y) + (v.vertex.xyz * transform.w);
                 v2f o;
                 o.pos = UnityObjectToClipPos(float4(worldPosition, 1.0f));
                 o.uv =  v.texcoord * uv.xy + uv.zw;

--- a/Assets/SpriteSheetRenderer/Material/SpriteSheet.shader
+++ b/Assets/SpriteSheetRenderer/Material/SpriteSheet.shader
@@ -59,7 +59,7 @@
                 //rotate the vertex
                 v.vertex = mul(v.vertex-float4(0.5,0.5,0,0),rotationZMatrix(transform.z));
                 //scale it
-                float3 worldPosition = float3(transform.x, transform.y, transform.y) + (v.vertex.xyz * transform.w);
+                float3 worldPosition = float3(transform.x,transform.y,-transform.y/10) + (v.vertex.xyz * transform.w);
                 v2f o;
                 o.pos = UnityObjectToClipPos(float4(worldPosition, 1.0f));
                 o.uv =  v.texcoord * uv.xy + uv.zw;


### PR DESCRIPTION
Fixed draw order to render top to bottom. Sprites were being rendered from bottom to top causing the sprites at the top being drawn on top of other sprites.
Normally sprites closer to the bottom are "closer" to the user, so they should be drawn last.